### PR TITLE
Screen Reader, Keyboard, a11y support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Hot or Cold</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -4,6 +4,7 @@ import Header from './header';
 import GuessSection from './guess-section';
 import GuessCount  from './guess-count';
 import GuessList from './guess-list';
+import InfoModal from './info-modal';
 
 export default class Game extends React.Component {
     constructor(props) {
@@ -11,7 +12,8 @@ export default class Game extends React.Component {
         this.state = {
             guesses: [],
             feedback: 'Make your guess!',
-            correctAnswer: Math.round(Math.random() * 100)
+            correctAnswer: Math.round(Math.random() * 100),
+            showInfoModal: false
         };
     }
 
@@ -55,16 +57,28 @@ export default class Game extends React.Component {
             feedback,
             guesses: [...this.state.guesses, guess]
         });
+
+        document.title = (feedback) ? `${feedback} | Hot or Cold` : 'Hot or Cold';
+    }
+
+    onToggleInfoModal = () => {
+      this.setState({
+          showInfoModal: !this.state.showInfoModal
+      });
     }
 
     render() {
         return (
             <div>
-                <Header onNewGame={() => this.newGame()}/>
-                <GuessSection feedback={this.state.feedback}
-                    onGuess={(guess) => this.guess(guess)} />
-                <GuessCount count={this.state.guesses.length} />
-                <GuessList guesses={this.state.guesses} />
+                <InfoModal hidden={!this.state.showInfoModal} aria-hidden={!this.state.showInfoModal} onClose={() => this.onToggleInfoModal()} />
+                <div aria-hidden={this.state.showInfoModal}>
+                  <Header onNewGame={() => this.newGame()} toggleInfoModal={this.onToggleInfoModal} />
+                  <GuessSection feedback={this.state.feedback}
+                      onGuess={(guess) => this.guess(guess)} />
+                  <GuessCount count={this.state.guesses.length} />
+                  <GuessList guesses={this.state.guesses} />
+                </div>
+
             </div>
         );
     }

--- a/src/components/guess-count.js
+++ b/src/components/guess-count.js
@@ -4,7 +4,7 @@ import './guess-count.css';
 
 export default function GuessCount(props) {
     return (
-        <p>
+        <p role="status" aria-live="polite" aria-atomic="true">
             Guess #<span id="count">{props.count}</span>!
         </p>
     );

--- a/src/components/guess-form.css
+++ b/src/components/guess-form.css
@@ -3,7 +3,7 @@ input {
 	height: 50px;
 	display: block;
 	padding: 0.8em 0;
-	margin: 0.8em auto 0;
+	margin: 0.8rem auto 0;
 	background: #50597b;
 	color: #fff;
 	border: solid 1px #1f253d;
@@ -24,7 +24,7 @@ input.button {
 	transition: background 1s ease-in-out;
 }
 
-input.button:hover {
+input.button:hover, input.button:focus {
 	background: #e64c65;
 	color: #fff;
 	-webkit-transition: background 1s ease-in-out;
@@ -41,8 +41,8 @@ input.text {
 	font-size: 2em;
 }
 
-input:focus {
-	outline: none !important;
+p {
+  color: white;
 }
 
 ::-webkit-input-placeholder {
@@ -54,9 +54,9 @@ input:focus {
 }
 
 ::-moz-placeholder {  /* Firefox 19+ */
-   color: #95a5a6; 
+   color: #95a5a6;
 }
 
-:-ms-input-placeholder {  
-   color: #95a5a6; 
+:-ms-input-placeholder {
+   color: #95a5a6;
 }

--- a/src/components/guess-form.js
+++ b/src/components/guess-form.js
@@ -17,8 +17,8 @@ export default class GuessForm extends React.Component {
         return (
             <form onSubmit={e => this.onGuess(e)}>
                 <label htmlFor="userGuess">Enter your Guess</label>
-                <input type="text" name="userGuess" id="userGuess"
-                    className="text" maxLength="3" autoComplete="off"
+                <input type="number" name="userGuess" id="userGuess"
+                    className="text" min="1" max="100" maxLength="3" autoComplete="off"
                     placeholder={Math.round(Math.random() * 100)} required
                     ref={input => this.input = input} />
                 <input type="submit" id="guessButton" className="button" name="submit" value="Guess"/>
@@ -26,4 +26,3 @@ export default class GuessForm extends React.Component {
         );
     }
 };
-

--- a/src/components/guess-list.css
+++ b/src/components/guess-list.css
@@ -21,3 +21,9 @@ ul.guessBox li {
 	margin: 0.2em;
 	color: #fff;
 }
+
+label {
+  color: white;
+  margin-top: 1em;
+  display: block;
+}

--- a/src/components/guess-list.js
+++ b/src/components/guess-list.js
@@ -4,13 +4,13 @@ import './guess-list.css';
 
 export default function GuessList(props) {
     const guesses = props.guesses.map((guess, index) => (
-        <li key={index}>
-            {guess}
+        <li aria-label={`${guess}`} key={index}>
+            <span className="visually-hidden">Guess #{index + 1} was </span>{guess}
         </li>
     ));
 
     return (
-        <ul id="guessList" className="guessBox clearfix">
+        <ul role="status" aria-live="polite" aria-atomic="true" id="guessList" className="guessBox clearfix">
             {guesses}
         </ul>
     );

--- a/src/components/guess-section.css
+++ b/src/components/guess-section.css
@@ -1,5 +1,5 @@
 h2 {
-	margin: 0 auto;	
+	margin: 0 auto;
 	background: #cc324b;
 	padding: 1em 0.4em;
 	font-size: 1.5em;
@@ -9,4 +9,9 @@ h2 {
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
 	color: #fff;
+  transition: background 240ms ease;
+}
+
+#feedback:target {
+  background: #9b1228;
 }

--- a/src/components/guess-section.js
+++ b/src/components/guess-section.js
@@ -6,10 +6,9 @@ import './guess-section.css';
 
 export default function GuessSection(props) {
     return (
-        <section>
-            <h2 id="feedback">{props.feedback}</h2>
+        <section aria-live="polite" role="status" aria-atomic="true">
+            <a href="#userGuess"><h2 id="feedback" >{props.feedback}</h2></a>
             <GuessForm onGuess={props.onGuess} />
         </section>
     );
 }
-

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,35 +1,16 @@
 import React from 'react';
 
 import TopNav from './top-nav';
-import InfoModal from './info-modal';
+
 
 import './header.css';
 
 export default class Header extends React.Component  {
-    constructor(props) {
-        super(props);
-        this.state = {
-            showInfoModal: false
-        };
-    }
-
-    toggleInfoModal() {
-        this.setState({
-            showInfoModal: !this.state.showInfoModal
-        });
-    }
-
     render() {
-        let infoModal;
-        if (this.state.showInfoModal) {
-            infoModal = <InfoModal onClose={() => this.toggleInfoModal()} />;
-        }
-
         return (
             <header>
-                <TopNav onInfo={() => this.toggleInfoModal()}
+                <TopNav onInfo={() => this.props.toggleInfoModal()}
                     onNewGame={this.props.onNewGame} />
-                {infoModal}
                 <h1>HOT or COLD</h1>
             </header>
         );

--- a/src/components/info-modal.css
+++ b/src/components/info-modal.css
@@ -47,28 +47,40 @@
 	text-align: justify;
 }
 
-.content > div ul {
+.content > div ol {
 	margin-bottom: -30px;
 	padding: 0 0 30px 20px;
 	text-align: left;
 }
 
-.content > div ul li {
+.content > div ol li {
 	padding: 5px 0;
-	display: block;	
-	list-style-type: disc;
 	line-height: 1.5em;
 }
 
-.content > div ul li strong{
-	text-decoration: underline;
+.content > div ol li strong {
+	font-weight: bold;
+  color: #e74c3c;
+  background: white;
+  padding-left: .25em;
+  padding-right: .25em;
 }
 
-.content > div a {
+.content > div button {
 	font-size: 0.8em;
 	background: #1F253D;
-	color: #95a5a6;
+	color: white;
 	padding: 0.5em 2em;
 	margin-bottom: 50px;
 	border-radius: 3px;
+  border: none;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  border: 2px solid #1F253D;
+}
+
+.content > div button:hover, .content > div button:focus {
+  background: white;
+  color: #1F253D;
 }

--- a/src/components/info-modal.js
+++ b/src/components/info-modal.js
@@ -10,20 +10,28 @@ export default class InfoModal extends React.Component {
         }
     }
 
+    componentDidMount() {
+      this.focusHeading();
+    }
+
+    focusHeading() {
+      this.heading.focus();
+    }
+
     render() {
         return (
-            <div className="overlay" id="modal">
+            <div hidden={this.props.hidden} aria-hidden={this.props.ariaHidden} className="overlay" id="modal">
                 <div className="content">
-                    <h3>What do I do?</h3>
+                    <h3 tabIndex="0" aria-describedby="game-goes-like-this" ref={heading => this.heading = heading}>What do I do?</h3>
                     <div>
-                        <p>This is a Hot or Cold Number Guessing Game. The game goes like this: </p>
-                        <ul>
-                            <li>1. I pick a <strong>random secret number</strong> between 1 to 100 and keep it hidden.</li>
-                            <li>2. You need to <strong>guess</strong> until you can find the hidden secret number.</li>
-                            <li>3. You will <strong>get feedback</strong> on how close ("hot") or far ("cold") your guess is.</li>
-                        </ul>
+                        <p id="game-goes-like-this">This is a Hot or Cold Number Guessing Game. The game goes like&nbsp;this:</p>
+                        <ol>
+                            <li>I pick a <strong>random secret number</strong> between 1 to 100 and keep it hidden.</li>
+                            <li>You need to <strong>guess</strong> until you can find the hidden secret number.</li>
+                            <li>You will <strong>get feedback</strong> on how close ("hot") or far ("cold") your guess is.</li>
+                        </ol>
                         <p>So, Are you ready?</p>
-                        <a className="close" href="#" onClick={e => this.onClose(e)}>Got It!</a>
+                        <button className="close" ref={button => this.closeBtn = button} onClick={e => this.onClose(e)} onBlur={e =>  this.focusHeading()}>Got It!</button>
                     </div>
                 </div>
             </div>

--- a/src/components/top-nav.js
+++ b/src/components/top-nav.js
@@ -4,7 +4,6 @@ import './top-nav.css';
 
 export default class TopNav extends React.Component {
     onNewGame(event) {
-        event.preventDefault();
         if (this.props.onNewGame) {
             this.props.onNewGame();
         }
@@ -22,12 +21,12 @@ export default class TopNav extends React.Component {
             <nav>
                 <ul className="clearfix">
                     <li>
-                        <a className="what" href="#" onClick={e => this.onInfo(e)}>
+                        <a className="what" aria-label="How to play" href="#modal" onClick={e => this.onInfo(e)}>
                             What?
                         </a>
                     </li>
                     <li>
-                        <a className="new" href="#" onClick={e => this.onNewGame(e)}>
+                        <a className="new" aria-live="Start a new game" href="#feedback" onClick={e => this.onNewGame(e)}>
                             + New Game
                         </a>
                     </li>
@@ -36,4 +35,3 @@ export default class TopNav extends React.Component {
         );
     }
 };
-

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,18 @@
 	box-sizing: border-box;
 }
 
+.visually-hidden { /*https://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html*/
+    position: absolute !important;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    padding:0 !important;
+    border:0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
+}
+body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .visually-hidden button { display: none !important; }
+
 html {
 	width: 100%;
 	height: 100%;
@@ -45,7 +57,6 @@ a {
 	color: black;
 }
 
-ul li {	
+ul li {
 	display: inline;
 }
-


### PR DESCRIPTION
### Does:
 - Red Make your guess banner is now clickable, focuses guess input
 - Guess input is now semantically a numeric input type, gains implicit
 - keyboard support
 - Modal window is accessible (aria-hidden, traps keyboard focus)
 - Changes `<a>` that should be buttons to `<button>`
 - What? is now a meaningful skip-to link `<a href=“#modal”>`
 - New game is now a meaningful skip-to link `<a href=“feedback”>` (sets focus to the make your guess banner)
 - Guess list is now politely read as it updates
 - Guess list items now read “Guess #1 was 37”
 - Changed strong styles in modal because only links should look like links (underline)
 - role="status" is used to indicate elements that they should be aware of (guesses)
 - ordered lists are `<ol>` because semantics
 - page title is now set
 - page title reflects feedback

Closes Thinkful-Ed/react-hot-cold#3

### Does Not
 - completely address success criteria for color contrast
 - ESC to close modal

@dengeist can you audit `aria-live`, `aria-atomic`, and `role="status"` on this? I'm using them to have the guess list, "You're hot" status, and guess number read back but it isn't always working. Not sure if it is a VO bug or something that should be marked up better.